### PR TITLE
fix densely-connected size

### DIFF
--- a/cnn_n_char.py
+++ b/cnn_n_char.py
@@ -58,6 +58,7 @@ def main(_):
     IMAGE_WIDTH = meta['width']
     IMAGE_SIZE = IMAGE_WIDTH * IMAGE_HEIGHT
     print('label_size: %s, image_size: %s' % (LABEL_SIZE, IMAGE_SIZE))
+    print('NUM_PER_IMAGE: %s, IMAGE_HEIGHT: %s, IMAGE_WIDTH: %s' % (NUM_PER_IMAGE, IMAGE_HEIGHT, IMAGE_WIDTH))
 
     # variable in the graph for input data
     with tf.name_scope('input'):
@@ -84,10 +85,11 @@ def main(_):
         h_pool2 = max_pool_2x2(h_conv2)
 
     with tf.name_scope('densely-connected'):
-        W_fc1 = weight_variable([IMAGE_WIDTH * IMAGE_HEIGHT * 4, 1024])
+        dc_size = ((h_pool2.shape[1] * 4) * (h_pool2.shape[2] * 4) * 4).value
+        W_fc1 = weight_variable([dc_size, 1024])
         b_fc1 = bias_variable([1024])
 
-        h_pool2_flat = tf.reshape(h_pool2, [-1, IMAGE_WIDTH*IMAGE_HEIGHT*4])
+        h_pool2_flat = tf.reshape(h_pool2, [-1, dc_size])
         h_fc1 = tf.nn.relu(tf.matmul(h_pool2_flat, W_fc1) + b_fc1)
 
     with tf.name_scope('dropout'):


### PR DESCRIPTION
When I try with height=50, I met this error:
```
InvalidArgumentError (see above for traceback): Incompatible shapes: [52,4] vs. [50,4]
```



```diff
diff --git a/datasets/gen_captcha.py b/datasets/gen_captcha.py
index 0e0bf46..492bca8 100644
--- a/datasets/gen_captcha.py
+++ b/datasets/gen_captcha.py
@@ -49,8 +49,8 @@ def gen_dataset():

     choices = get_choices()

-    width = 40 + 20 * num_per_image
-    height = 100
+    width = 100 # 40 + 20 * num_per_image
+    height = 50 # 100

     # meta info
     meta = {
```

