### PR TITLE
Fixed ValueError: invalid literal for int()

### DIFF
--- a/captcha-solver-tf2-4digits-AlexNet-98.8.ipynb
+++ b/captcha-solver-tf2-4digits-AlexNet-98.8.ipynb
@@ -48,7 +48,7 @@
     "# DATA_DIR = '/home/jackon/captcha-tensorflow/images/char-4-epoch-6/train'  # 30241 images. validate accuracy: 87.6%\n",
     "DATA_DIR = '/home/jackon/captcha-tensorflow/images/char-4-epoch-60/train'  # 302410 images. validate accuracy: 98.8%\n",
     "H, W, C = 100, 120, 3\n",
-    "N_LABELS = 10\n",
+    "N_LABELS = 256\n",
     "D = 4"
    ]
   },
@@ -202,7 +202,7 @@
     "#             im = im.resize((H, W))\n",
     "            im = np.array(im) / 255.0\n",
     "            images.append(np.array(im))\n",
-    "            labels.append(np.array([np.array(to_categorical(int(i), N_LABELS)) for i in label]))\n",
+    "            labels.append(np.array([np.array(to_categorical(ord(i), N_LABELS)) for i in label]))\n",
     "            if len(images) >= batch_size:\n",
     "#                 print(np.array(images), np.array(labels))\n",
     "                yield np.array(images), np.array(labels)\n",
@@ -446,10 +446,10 @@
     "for i, img_idx in enumerate(random_indices):\n",
     "    ax = axes.flat[i]\n",
     "    ax.imshow(x_test[img_idx])\n",
-    "    ax.set_title('pred: {}'.format(\n",
-    "        ''.join(map(str, y_pred[img_idx].numpy()))))\n",
-    "    ax.set_xlabel('true: {}'.format(\n",
-    "        ''.join(map(str, y_true[img_idx].numpy()))))\n",
+    "ax.set_title(chr(int(y_pred[img_idx][0]))+chr(int(y_pred[img_idx][1]))+chr(int(y_pred[img_idx][2]))+\
+                chr(int(y_pred[img_idx][3])))",
+    "ax.set_xlabel(chr(int(y_true[img_idx][0]))+chr(int(y_true[img_idx][1]))+chr(int(y_true[img_idx][2]))+\
+                chr(int(y_true[img_idx][3])))",
     "    ax.set_xticks([])\n",
     "    ax.set_yticks([])"
    ]


### PR DESCRIPTION
The int conversation is not allowed. It doesn't work at all. Replacement to `ord` and `chr` after that works fine. Python > 3.7, tensorflow >=2.1.0. You can summarize chr conversation for n-character case ( `for` somehow). I use only 4 character.